### PR TITLE
Potential Preference Change

### DIFF
--- a/examples/grade.inc.php
+++ b/examples/grade.inc.php
@@ -90,8 +90,8 @@ abstract class Tester {
     //increment the static counter for unique IDs
     Tester::$collapseIdCounter++;
     $jsCommand = "\$(\"#collapseId" . Tester::$collapseIdCounter . "\").toggle(\"blind\"); $(this).text() == \"[-]\"?$(this).text(\"[+]\"):$(this).text(\"[-]\");";
-    $htmlDiv = "<div style='clear: both'><h2><span style='cursor: pointer;' onclick='$jsCommand'>[-]</span> $title</h2></div>\n" .
-               "<div id='collapseId" . Tester::$collapseIdCounter . "' style='margin-left: 2em;'>" . $content  . "</div>";
+    $htmlDiv = "<div style='clear: both'><h2><span style='cursor: pointer;' onclick='$jsCommand'>[+]</span> $title</h2></div>\n" .
+               "<div id='collapseId" . Tester::$collapseIdCounter . "' style='margin-left: 2em;display:none;'>" . $content  . "</div>";
     return $htmlDiv;
   }
 

--- a/examples/grade.inc.php
+++ b/examples/grade.inc.php
@@ -85,12 +85,17 @@ abstract class Tester {
   /**
    * Formats the given $content inside a collapsible <div> element
    */
-  public static function getCollapsibleDiv($title, $content) {
+  public static function getCollapsibleDiv($title, $content, $divIsOpen = true) {
     //increment the static counter for unique IDs
     Tester::$collapseIdCounter++;
     $jsCommand = "\$(\"#collapseId" . Tester::$collapseIdCounter . "\").toggle(\"blind\"); $(this).text() == \"[-]\"?$(this).text(\"[+]\"):$(this).text(\"[-]\");";
-    $htmlDiv = "<div style='clear: both'><h2><span style='cursor: pointer;' onclick='$jsCommand'>[+]</span> $title</h2></div>\n" .
+    if($divIsOpen) {
+	  $htmlDiv = "<div style='clear: both'><h2><span style='cursor: pointer;' onclick='$jsCommand'>[-]</span> $title</h2></div>\n" .
+               "<div id='collapseId" . Tester::$collapseIdCounter . "' style='margin-left: 2em;'>" . $content  . "</div>";
+    } else {
+	    $htmlDiv = "<div style='clear: both'><h2><span style='cursor: pointer;' onclick='$jsCommand'>[+]</span> $title</h2></div>\n" .
                "<div id='collapseId" . Tester::$collapseIdCounter . "' style='margin-left: 2em;display:none;'>" . $content  . "</div>";
+    }
     return $htmlDiv;
   }
 
@@ -205,7 +210,7 @@ abstract class Tester {
       $sourceFileDivs = "";
       foreach($this->sourceFiles as $file => $contents) {
         $divContent = '<pre class="prettyprint linenums"><code">' . htmlentities($contents) . '</code></pre>';
-        $collapsibleDiv = self::getCollapsibleDiv($file, $divContent);
+        $collapsibleDiv = self::getCollapsibleDiv($file, $divContent, false);
 	$sourceFileDivs .= $collapsibleDiv;
       }
       if(!empty($sourceFileDivs)) {

--- a/examples/grade.inc.php
+++ b/examples/grade.inc.php
@@ -86,7 +86,6 @@ abstract class Tester {
    * Formats the given $content inside a collapsible <div> element
    */
   public static function getCollapsibleDiv($title, $content) {
-
     //increment the static counter for unique IDs
     Tester::$collapseIdCounter++;
     $jsCommand = "\$(\"#collapseId" . Tester::$collapseIdCounter . "\").toggle(\"blind\"); $(this).text() == \"[-]\"?$(this).text(\"[+]\"):$(this).text(\"[-]\");";


### PR DESCRIPTION
Double check my work, I am not super experienced with PHP

I find scrolling past like 20 classes slightly annoying when I only care about a few for a given submission or if I am rerunning the grader for correctness purposes. So, this change (hopefully, barring a syntactic mistake) would change the source file section on the grader page to be collapsed by default. 